### PR TITLE
Raw string writing into file; autolocking pattern

### DIFF
--- a/test/test_win32_mmap.rb
+++ b/test/test_win32_mmap.rb
@@ -45,6 +45,12 @@ class TC_Win32_Mmap < Test::Unit::TestCase
     assert_equal([{1=>2}, [1,2,3], 'foo'], @mmap.barray)
   end
 
+  test "primitive write/read of file" do
+    input = "Greetings, astute reader"
+    assert_nothing_raised{ @mmap.write_string(input) }
+    assert_equal(input, @mmap.read_string(input.length))
+  end
+
   test "passing an invalid option raises an argument error" do
     assert_raises(ArgumentError){ MMap.new(:foo => 1) }
   end


### PR DESCRIPTION
> A number of methods used the same pattern of doing something in the
> context of autolock present or not. This commit exposes this pattern
> and makes it reusable.
> Additionally a method is available to write a string directly to the
> Memory-Mapped file and a corresponding read method. An additional test checks this functionality.

Would be nice if this function would be available directly in the gem - Background: I am using this library to exchange data with a .NET process; That one doesn't have a clue about the way hte hash is serialized into the file, so a possibility to enter raw string input is maybe not so bad.
