### PR TITLE
Ruby Version Support for 3.4.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+---
+name: lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: false
+      - uses: r7kamura/rubocop-problem-matchers-action@v1  # this shows the failures in the PR
+      - run: |
+          gem install cookstyle
+          cookstyle --chefstyle -c .rubocop.yml
+  

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,33 @@
+---
+name: unit
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2022, windows-2025]
+        ruby: ['3.1', '3.4']
+    name: Unit test on ${{ matrix.os }} with Ruby ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}
+    env:
+      RUBYOPT: '--disable-error_highlight'
+    steps:
+      - uses: actions/checkout@v4
+      - name: ruby-setup
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: false
+      - run: |
+          bundle install --jobs 4 --retry 3
+          bundle exec rake test

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ coverage
 pkg
 */tags
 *~
+.ruby-version
 
 # you should check in your Gemfile.lock in applications, and not in gems
 Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,45 @@
+AllCops:
+  TargetRubyVersion: 2.7
+
+  Exclude:
+    - 'appveyor.yml'
+    - 'Vagrantfile'
+    - 'scripts/**/*'
+    - 'vendor/**/*'
+
+Style/Encoding:
+  Enabled: true
+
+Style/NumericLiterals:
+  Enabled: false
+
+Layout/EndOfLine:
+  Enabled: false
+
+Layout/HeredocIndentation:
+  Enabled: false
+
+Metrics/BlockLength:
+  Max: 200
+
+Layout/LineLength:
+  Max: 120
+
+Metrics/MethodLength:
+  Max: 20
+
+Metrics/ModuleLength:
+  Max: 250
+
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+
+Naming/FileName:
+  Enabled: false
+
+Metrics/ClassLength:
+  Max: 250
+
+Metrics/AbcSize:
+  Max: 26
+

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,10 @@ group :docs do
   gem "github-markup"
 end
 
+group :style do
+  gem "cookstyle", "~> 8.1"
+end
+
 group :debug do
   gem "pry"
   gem "pry-byebug"

--- a/Rakefile
+++ b/Rakefile
@@ -1,22 +1,22 @@
-require 'rake/clean'
-require 'rake/testtask'
+require "rake/clean"
+require "rake/testtask"
 
-CLEAN.include('**/*.gem')
+CLEAN.include("**/*.gem")
 
-namespace 'example' do
-  desc 'Run the example mmap file program'
+namespace "example" do
+  desc "Run the example mmap file program"
   task :file do
-    ruby '-Ilib examples/example_mmap_file.rb'
+    ruby "-Ilib examples/example_mmap_file.rb"
   end
 
-  desc 'Run the example mmap server'
+  desc "Run the example mmap server"
   task :server do
-    ruby '-Ilib examples/example_mmap_server.rb'
+    ruby "-Ilib examples/example_mmap_server.rb"
   end
 
-  desc 'Run the example mmap client'
+  desc "Run the example mmap client"
   task :client do
-    ruby '-Ilib examples/example_mmap_client.rb'
+    ruby "-Ilib examples/example_mmap_client.rb"
   end
 end
 
@@ -32,6 +32,22 @@ rescue LoadError
   puts "yard is not available. bundle install first to make sure all dependencies are installed."
 end
 
+desc "Check Linting and code style."
+task :style do
+  require "rubocop/rake_task"
+  require "cookstyle/chefstyle"
+
+  if RbConfig::CONFIG["host_os"] =~ /mswin|mingw|cygwin/
+    # Windows-specific command, rubocop erroneously reports the CRLF in each file which is removed when your PR is uploaeded to GitHub.
+    # This is a workaround to ignore the CRLF from the files before running cookstyle.
+    sh "cookstyle --chefstyle -c .rubocop.yml --except Layout/EndOfLine"
+  else
+    sh "cookstyle --chefstyle -c .rubocop.yml"
+  end
+rescue LoadError
+  puts "Rubocop or Cookstyle gems are not installed. bundle install first to make sure all dependencies are installed."
+end
+
 task :console do
   require "irb"
   require "irb/completion"
@@ -39,4 +55,4 @@ task :console do
   IRB.start
 end
 
-task :default => :test
+task default: :test

--- a/examples/example_mmap_client.rb
+++ b/examples/example_mmap_client.rb
@@ -9,10 +9,10 @@
 #
 # Modify this program as you see fit.
 #######################################################################
-require 'win32/mmap'
+require "win32/mmap"
 include Win32
 
-mmap = MMap.open('alpha')
+mmap = MMap.open("alpha")
 
 p mmap.foo
 p mmap.bar

--- a/examples/example_mmap_file.rb
+++ b/examples/example_mmap_file.rb
@@ -7,17 +7,17 @@
 #
 # Modify this program as you see fit.
 #######################################################################
-require 'win32/mmap'
+require "win32/mmap"
 include Win32
 
-map1 = MMap.new(:file => "C:\\mmap.test", :size => 1024)
+map1 = MMap.new(file: "C:\\mmap.test", size: 1024)
 
-map1.foo = 'hello'
+map1.foo = "hello"
 map1.bar = 77
 
 map1.close
 
-map2 = MMap.new(:file => "C:\\mmap.test")
+map2 = MMap.new(file: "C:\\mmap.test")
 
 p map2.foo
 p map2.bar

--- a/examples/example_mmap_server.rb
+++ b/examples/example_mmap_server.rb
@@ -4,15 +4,15 @@
 # A test script for general futzing.  Run this in its own terminal
 # then run the example_mmap_client.rb program in a separate terminal.
 # You can run this program via the 'rake example_server' task.
-# 
-# Modify as you see fit. 
+#
+# Modify as you see fit.
 #######################################################################
-require 'win32/mmap'
+require "win32/mmap"
 include Win32
 
-mmap = MMap.new(:name => 'alpha', :size => 2000)
+mmap = MMap.new(name: "alpha", size: 2000)
 
-mmap.foo = 'hello'
+mmap.foo = "hello"
 mmap.bar = 27
 
 sleep 100

--- a/lib/win32-mmap.rb
+++ b/lib/win32-mmap.rb
@@ -1,1 +1,1 @@
-require_relative 'win32/mmap'
+require_relative "win32/mmap"

--- a/lib/win32/windows/constants.rb
+++ b/lib/win32/windows/constants.rb
@@ -4,7 +4,6 @@ module Windows
   module Constants
     include FFI::Library
 
-
     GENERIC_READ  = 0x80000000
     GENERIC_WRITE = 0x40000000
     OPEN_ALWAYS   = 4

--- a/lib/win32/windows/constants.rb
+++ b/lib/win32/windows/constants.rb
@@ -1,10 +1,9 @@
-require 'ffi'
+require "ffi" unless defined?(FFI)
 
 module Windows
   module Constants
     include FFI::Library
 
-    private
 
     GENERIC_READ  = 0x80000000
     GENERIC_WRITE = 0x40000000

--- a/lib/win32/windows/functions.rb
+++ b/lib/win32/windows/functions.rb
@@ -1,4 +1,4 @@
-require 'ffi'
+require "ffi" unless defined?(FFI)
 
 module Windows
   module Functions
@@ -21,30 +21,30 @@ module Windows
     attach_pfunc :CloseHandle, [:handle], :bool
 
     attach_pfunc :CreateFile, :CreateFileA,
-      [:str, :dword, :dword, :pointer, :dword, :dword, :handle],
+      %i{str dword dword pointer dword dword handle},
       :handle
 
     attach_pfunc :CreateFileMapping, :CreateFileMappingA,
-      [:handle, :pointer, :dword, :dword, :dword, :str],
+      %i{handle pointer dword dword dword str},
       :handle
 
     attach_pfunc :CreateSemaphore, :CreateSemaphoreA,
-      [:pointer, :long, :long, :str],
+      %i{pointer long long str},
       :handle
 
-    attach_pfunc :FlushViewOfFile, [:uintptr_t, :size_t], :bool
+    attach_pfunc :FlushViewOfFile, %i{uintptr_t size_t}, :bool
 
     attach_pfunc :MapViewOfFileEx,
-      [:handle, :dword, :dword, :dword, :size_t, :uintptr_t],
+      %i{handle dword dword dword size_t uintptr_t},
       :uintptr_t
 
     attach_pfunc :OpenFileMapping, :OpenFileMappingA,
-      [:dword, :bool, :str],
+      %i{dword bool str},
       :handle
 
-    attach_pfunc :ReleaseSemaphore, [:handle, :long, :pointer], :bool
+    attach_pfunc :ReleaseSemaphore, %i{handle long pointer}, :bool
     attach_pfunc :UnmapViewOfFile, [:uintptr_t], :bool
-    attach_pfunc :WaitForSingleObject, [:handle, :dword], :dword
-    attach_pfunc :VirtualQuery, [:uintptr_t, :pointer, :size_t], :size_t
+    attach_pfunc :WaitForSingleObject, %i{handle dword}, :dword
+    attach_pfunc :VirtualQuery, %i{uintptr_t pointer size_t}, :size_t
   end
 end

--- a/lib/win32/windows/structs.rb
+++ b/lib/win32/windows/structs.rb
@@ -1,4 +1,4 @@
-require 'ffi'
+require "ffi" unless defined?(FFI)
 
 module Windows
   module Structs

--- a/lib/win32/windows/version.rb
+++ b/lib/win32/windows/version.rb
@@ -1,6 +1,6 @@
 module Win32
   class MMap
-    VERSION = "0.4.2"
+    VERSION = "0.4.2".freeze
     MAJOR, MINOR, TINY = VERSION.split(".")
   end
 end

--- a/test/test_win32_mmap.rb
+++ b/test/test_win32_mmap.rb
@@ -4,72 +4,72 @@
 # Test suite for the win32-mmap package. This should be run via the
 # 'rake test' task.
 #####################################################################
-require 'test-unit'
-require 'win32/mmap'
+require "test-unit"
+require "win32/mmap"
 include Win32
 
 class TC_Win32_Mmap < Test::Unit::TestCase
   def setup
-    @mmap = MMap.new(:name => 'test', :size => 100)
+    @mmap = MMap.new(name: "test", size: 100)
   end
 
   test "version is set to expected value" do
-    assert_equal('0.4.2', MMap::VERSION)
+    assert_equal("0.4.2", MMap::VERSION)
   end
 
   test "dynamic variable names and string values work as expected" do
-    assert_nothing_raised{ @mmap.foo = 'test' }
-    assert_nothing_raised{ @mmap.bar = 'alpha123' }
-    assert_equal('test', @mmap.foo)
-    assert_equal('alpha123', @mmap.bar)
+    assert_nothing_raised { @mmap.foo = "test" }
+    assert_nothing_raised { @mmap.bar = "alpha123" }
+    assert_equal("test", @mmap.foo)
+    assert_equal("alpha123", @mmap.bar)
   end
 
   test "dynamic variable names and integer values work as expected" do
-    assert_nothing_raised{ @mmap.bar = 7 }
-    assert_nothing_raised{ @mmap.zero = 0 }
+    assert_nothing_raised { @mmap.bar = 7 }
+    assert_nothing_raised { @mmap.zero = 0 }
     assert_equal(7, @mmap.bar)
     assert_equal(0, @mmap.zero)
   end
 
   test "dynamic variable names and hash values work as expected" do
-    assert_nothing_raised{ @mmap.ahash = {'foo' => 0} }
-    assert_nothing_raised{ @mmap.bhash = {'foo' => 0, 'bar' => 'hello'} }
-    assert_equal({'foo' => 0}, @mmap.ahash)
-    assert_equal({'foo' => 0, 'bar' => 'hello'}, @mmap.bhash)
+    assert_nothing_raised { @mmap.ahash = { "foo" => 0 } }
+    assert_nothing_raised { @mmap.bhash = { "foo" => 0, "bar" => "hello" } }
+    assert_equal({ "foo" => 0 }, @mmap.ahash)
+    assert_equal({ "foo" => 0, "bar" => "hello" }, @mmap.bhash)
   end
 
   test "dynamic variable names and array values work as expected" do
-    assert_nothing_raised{ @mmap.aarray = [1, 'x', 3] }
-    assert_nothing_raised{ @mmap.barray = [{1 => 2}, [1,2,3], 'foo'] }
-    assert_equal([1, 'x', 3], @mmap.aarray)
-    assert_equal([{1=>2}, [1,2,3], 'foo'], @mmap.barray)
+    assert_nothing_raised { @mmap.aarray = [1, "x", 3] }
+    assert_nothing_raised { @mmap.barray = [{ 1 => 2 }, [1, 2, 3], "foo"] }
+    assert_equal([1, "x", 3], @mmap.aarray)
+    assert_equal([{ 1 => 2 }, [1, 2, 3], "foo"], @mmap.barray)
   end
 
   test "primitive write/read of file" do
     input = "Greetings, astute reader"
-    assert_nothing_raised{ @mmap.write_string(input) }
+    assert_nothing_raised { @mmap.write_string(input) }
     assert_equal(input, @mmap.read_string(input.length))
   end
 
   test "passing an invalid option raises an argument error" do
-    assert_raises(ArgumentError){ MMap.new(:foo => 1) }
+    assert_raises(ArgumentError) { MMap.new(foo: 1) }
   end
 
   test "address method basic functionality" do
     assert_respond_to(@mmap, :address)
-    assert_kind_of(Fixnum, @mmap.address)
+    assert_kind_of(Integer, @mmap.address)
   end
 
   test "base_address method basic functionality" do
     assert_respond_to(@mmap, :base_address)
     assert_respond_to(@mmap, :base_address=)
-    assert_kind_of(Fixnum, @mmap.base_address)
+    assert_kind_of(Integer, @mmap.base_address)
   end
 
   test "name accessor basic functionality" do
     assert_respond_to(@mmap, :name)
     assert_respond_to(@mmap, :name=)
-    assert_equal('test', @mmap.name)
+    assert_equal("test", @mmap.name)
   end
 
   test "inherit accessor basic functionality" do

--- a/win32-mmap.gemspec
+++ b/win32-mmap.gemspec
@@ -1,23 +1,23 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "win32/windows/version"
 
 Gem::Specification.new do |spec|
-  spec.name       = 'win32-mmap'
+  spec.name       = "win32-mmap"
   spec.version    = Win32::MMap::VERSION
-  spec.author     = 'Daniel J. Berger'
-  spec.license    = 'Artistic 2.0'
-  spec.email      = 'djberg96@gmail.com'
-  spec.homepage   = 'https://github.com/chef/win32-mmap'
-  spec.summary    = 'Memory mapped IO for Windows.'
-  spec.test_file  = 'test/test_win32_mmap.rb'
-  spec.files      = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(\..*|Gemfile|Rakefile|doc|examples|VERSION|test)}) }
+  spec.author     = "Daniel J. Berger"
+  spec.license    = "Artistic 2.0"
+  spec.email      = "djberg96@gmail.com"
+  spec.homepage   = "https://github.com/chef/win32-mmap"
+  spec.summary    = "Memory mapped IO for Windows."
+  spec.test_file  = "test/test_win32_mmap.rb"
+  spec.files      = `git ls-files -z`.split("\x0").reject { |f| f.match(/^(\..*|Gemfile|Rakefile|doc|examples|VERSION|test)/) }
 
-  spec.extra_rdoc_files  = ['README.md']
+  spec.extra_rdoc_files = ["README.md"]
 
-  spec.add_dependency('ffi')
-  spec.add_development_dependency('rake')
-  spec.add_development_dependency('test-unit')
+  spec.add_dependency("ffi")
+  spec.add_development_dependency("rake")
+  spec.add_development_dependency("test-unit")
 
   spec.description = <<-EOF
     The win32-mmap library provides an interface for memory mapped IO on


### PR DESCRIPTION
### Description

Chef Infra is upgrading all the things to support Ruby 3.4.2 and later. We're also moving to Cookstyle for linting. Those changes are below.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
